### PR TITLE
feat: Add ISO 8601 date prefix to downloaded filenames

### DIFF
--- a/src/utils/__tests__/file-utils.test.ts
+++ b/src/utils/__tests__/file-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { downloadMarkdown } from '../file-utils';
 
 // Mock document methods
@@ -14,6 +14,10 @@ const mockRevokeObjectURL = vi.fn();
 describe('file-utils', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    
+    // Mock the current date to ensure consistent test results
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-14'));
 
     // Setup document mocks
     mockCreateElement.mockReturnValue({
@@ -37,6 +41,10 @@ describe('file-utils', () => {
       size: content[0].length,
       type: options.type,
     })) as unknown as typeof Blob;
+  });
+  
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('downloadMarkdown', () => {
@@ -147,7 +155,7 @@ describe('file-utils', () => {
       });
 
       const anchorElement = mockCreateElement.mock.results[0].value;
-      expect(anchorElement.download).toBe('apple-developer-documentation-swiftui-docs.md');
+      expect(anchorElement.download).toBe('2025-06-14_apple-developer-documentation-swiftui-docs.md');
     });
 
     it('should generate correct filename for Swift Package Index', () => {
@@ -160,7 +168,7 @@ describe('file-utils', () => {
       });
 
       const anchorElement = mockCreateElement.mock.results[0].value;
-      expect(anchorElement.download).toBe('swift-package-index-vapor-vapor-docs.md');
+      expect(anchorElement.download).toBe('2025-06-14_swift-package-index-vapor-vapor-docs.md');
     });
 
     it('should generate correct filename for GitHub Pages', () => {
@@ -173,8 +181,7 @@ describe('file-utils', () => {
       });
 
       const anchorElement = mockCreateElement.mock.results[0].value;
-      expect(anchorElement.download).toContain('github-pages');
-      expect(anchorElement.download).toContain('docs.md');
+      expect(anchorElement.download).toBe('2025-06-14_github-pages----github-io--swift-composable-architecture-docs.md');
     });
 
     it('should handle results with only empty content', () => {

--- a/src/utils/__tests__/url-utils.test.ts
+++ b/src/utils/__tests__/url-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   isValidDocumentationUrl,
   getSupportedDomainsText,
@@ -94,52 +94,74 @@ describe('url-utils', () => {
   });
 
   describe('generateFilename', () => {
-    it('should generate Apple Developer filenames', () => {
+    beforeEach(() => {
+      // Mock the current date to ensure consistent test results
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2025-06-14'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+    it('should generate Apple Developer filenames with date prefix', () => {
       expect(generateFilename('https://developer.apple.com/documentation/swiftui')).toBe(
-        'apple-developer-documentation-swiftui-docs.md'
+        '2025-06-14_apple-developer-documentation-swiftui-docs.md'
       );
       expect(generateFilename('https://developer.apple.com/documentation/uikit/uiview')).toBe(
-        'apple-developer-documentation-uikit-docs.md'
+        '2025-06-14_apple-developer-documentation-uikit-docs.md'
       );
       expect(generateFilename('https://developer.apple.com/documentation/')).toBe(
-        'apple-developer-documentation-docs.md'
+        '2025-06-14_apple-developer-documentation-docs.md'
       );
     });
 
-    it('should generate Swift Package Index filenames', () => {
+    it('should generate Swift Package Index filenames with date prefix', () => {
       expect(
         generateFilename('https://swiftpackageindex.com/pointfreeco/swift-composable-architecture')
-      ).toBe('swift-package-index-pointfreeco-swift-composable-architecture-docs.md');
+      ).toBe('2025-06-14_swift-package-index-pointfreeco-swift-composable-architecture-docs.md');
       expect(generateFilename('https://swiftpackageindex.com/vapor/vapor')).toBe(
-        'swift-package-index-vapor-vapor-docs.md'
+        '2025-06-14_swift-package-index-vapor-vapor-docs.md'
       );
       expect(generateFilename('https://swiftpackageindex.com/')).toBe(
-        'swift-package-index-docs.md'
+        '2025-06-14_swift-package-index-docs.md'
       );
     });
 
-    it('should generate GitHub Pages filenames', () => {
+    it('should generate GitHub Pages filenames with date prefix', () => {
       expect(generateFilename('https://pointfreeco.github.io/swift-composable-architecture/')).toBe(
-        'github-pages----github-io--swift-composable-architecture-docs.md'
+        '2025-06-14_github-pages----github-io--swift-composable-architecture-docs.md'
       );
       expect(
         generateFilename(
           'https://pointfreeco.github.io/swift-composable-architecture/documentation/composablearchitecture'
         )
-      ).toBe('github-pages----github-io--swift-composable-architecture-documentation-docs.md');
+      ).toBe('2025-06-14_github-pages----github-io--swift-composable-architecture-documentation-docs.md');
       expect(generateFilename('https://example.github.io/')).toBe(
-        'github-pages----github-io--docs.md'
+        '2025-06-14_github-pages----github-io--docs.md'
       );
     });
 
-    it('should handle invalid URLs gracefully', () => {
-      expect(generateFilename('not-a-url')).toBe('documentation.md');
-      expect(generateFilename('')).toBe('documentation.md');
+    it('should handle invalid URLs gracefully with date prefix', () => {
+      expect(generateFilename('not-a-url')).toBe('2025-06-14_documentation.md');
+      expect(generateFilename('')).toBe('2025-06-14_documentation.md');
     });
 
-    it('should handle other domains', () => {
-      expect(generateFilename('https://example.com/docs/api')).toBe('example-com-docs-docs.md');
-      expect(generateFilename('https://example.com/')).toBe('example-com-docs.md');
+    it('should handle other domains with date prefix', () => {
+      expect(generateFilename('https://example.com/docs/api')).toBe('2025-06-14_example-com-docs-docs.md');
+      expect(generateFilename('https://example.com/')).toBe('2025-06-14_example-com-docs.md');
+    });
+
+    it('should use correct ISO 8601 date format', () => {
+      // Test different dates to ensure proper formatting
+      vi.setSystemTime(new Date('2025-01-01'));
+      expect(generateFilename('https://example.com/')).toBe('2025-01-01_example-com-docs.md');
+      
+      vi.setSystemTime(new Date('2025-12-31'));
+      expect(generateFilename('https://example.com/')).toBe('2025-12-31_example-com-docs.md');
+      
+      // Test with single digit month and day
+      vi.setSystemTime(new Date('2025-03-05'));
+      expect(generateFilename('https://example.com/')).toBe('2025-03-05_example-com-docs.md');
     });
   });
 });

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -59,6 +59,13 @@ export function normalizeUrl(url: string): string {
 }
 
 export function generateFilename(url: string): string {
+  // Get current date in YYYY-MM-DD format (ISO 8601)
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const datePrefix = `${year}-${month}-${day}_`;
+
   try {
     const urlObj = new URL(url);
     const hostname = urlObj.hostname;
@@ -82,18 +89,18 @@ export function generateFilename(url: string): string {
       if (pathParts.length > 0) {
         // Take up to 2 path parts for the filename
         const pathSuffix = pathParts.slice(0, 2).join('-');
-        return `${baseName}-${pathSuffix}-docs.md`;
+        return `${datePrefix}${baseName}-${pathSuffix}-docs.md`;
       }
-      return `${baseName}-docs.md`;
+      return `${datePrefix}${baseName}-docs.md`;
     }
 
     // Fallback: use the hostname and any path
     const pathParts = pathname.split('/').filter((p) => p);
     if (pathParts.length > 0) {
-      return `${hostname.replace(/\./g, '-')}-${pathParts[0]}-docs.md`;
+      return `${datePrefix}${hostname.replace(/\./g, '-')}-${pathParts[0]}-docs.md`;
     }
-    return `${hostname.replace(/\./g, '-')}-docs.md`;
+    return `${datePrefix}${hostname.replace(/\./g, '-')}-docs.md`;
   } catch {
-    return 'documentation.md';
+    return `${datePrefix}documentation.md`;
   }
 }


### PR DESCRIPTION
 ## Summary

  This PR implements the feature requested in [#1](https://github.com/amantus-ai/llm-codes/issues/1) to add ISO 8601 date prefixes (YYYY-MM-DD) to all downloaded markdown files, making them automatically sortable by date.

  ## Changes

  - Modified `generateFilename()` function in `src/utils/url-utils.ts` to prepend the current date in `YYYY-MM-DD_` format
  - Updated all related tests to mock the current date for consistent test results
  - All downloaded files now follow the pattern: `2025-06-14_filename.md`

  ## Examples

  **Before:**
  - `apple-developer-documentation-swiftui-docs.md`
  - `swift-package-index-vapor-vapor-docs.md`

  **After:**
  - `2025-06-14_apple-developer-documentation-swiftui-docs.md`
  - `2025-06-14_swift-package-index-vapor-vapor-docs.md`

  ## Benefits
  - Files are now automatically sortable by date in file explorers
  - Follows ISO 8601 standard for date formatting
  - Makes it easier to track when documentation was downloaded
  - No breaking changes - existing functionality remains intact

  ## Testing

  - ✅ All existing tests updated and passing
  - ✅ TypeScript type checking passes
  - ✅ Added date format validation tests


  As suggested in the issue, this follows [XKCD 1179](https://xkcd.com/1179/) best practices for date formatting.
  ---