### PR TITLE
feat: add Telegram Bot API documentation support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,6 +66,12 @@ export const ALLOWED_EXCEPTIONS = {
     example: 'https://tauri.app/',
     category: 'Desktop Frameworks',
   },
+  TELEGRAM: {
+    pattern: 'https://core.telegram.org/',
+    name: 'Telegram Bot API',
+    example: 'https://core.telegram.org/bots',
+    category: 'Messaging Platforms',
+  },
 } as const;
 
 // Legacy support for specific domains that need special handling

--- a/src/utils/__tests__/url-utils.test.ts
+++ b/src/utils/__tests__/url-utils.test.ts
@@ -165,6 +165,15 @@ describe('url-utils', () => {
         expect(isValidDocumentationUrl('https://tauri.app/')).toBe(true);
         expect(isValidDocumentationUrl('https://tauri.app/v1/guides/')).toBe(true);
       });
+
+      it('should validate Telegram Bot API', () => {
+        expect(isValidDocumentationUrl('https://core.telegram.org/')).toBe(true);
+        expect(isValidDocumentationUrl('https://core.telegram.org/bots')).toBe(true);
+        expect(isValidDocumentationUrl('https://core.telegram.org/bots/api')).toBe(true);
+        // Lookalike domains must not match
+        expect(isValidDocumentationUrl('https://core.telegram.org.evil.com')).toBe(false);
+        expect(isValidDocumentationUrl('https://core.telegram.org.evil.com/bots')).toBe(false);
+      });
     });
 
     describe('Edge Cases', () => {


### PR DESCRIPTION
## Summary

- Adds `core.telegram.org` as an explicit exception in `ALLOWED_EXCEPTIONS` so Telegram's developer documentation passes URL validation
- Covers the full Telegram Bot API reference (e.g. `https://core.telegram.org/bots`, `https://core.telegram.org/bots/api`)
- Adds test coverage for the new exception alongside the existing ones

## Test plan

- [x] Verify `https://core.telegram.org/bots` passes `isValidDocumentationUrl`
- [x] Verify `https://core.telegram.org/bots/api` passes `isValidDocumentationUrl`
- [x] Run `npm test` — all existing tests continue to pass
