### PR TITLE
Support self-hosted Playwright scraping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ FIRECRAWL_API_KEY=your_api_key_here
 
 # Required once per self-hosted machine when SCRAPE_PROVIDER=playwright:
 # pnpm exec playwright install chromium
+# Remote Playwright endpoints are unsupported; do not set PLAYWRIGHT_WS_ENDPOINT.
 # PLAYWRIGHT_TIMEOUT_MS=60000
 # PLAYWRIGHT_WAIT_MS=30000
 

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
-# Required: Firecrawl API Configuration
+# Scrape provider: firecrawl (default) or playwright
+SCRAPE_PROVIDER=firecrawl
+
+# Required when SCRAPE_PROVIDER=firecrawl
 FIRECRAWL_API_KEY=your_api_key_here
+
+# Required once per self-hosted machine when SCRAPE_PROVIDER=playwright:
+# pnpm exec playwright install chromium
+# PLAYWRIGHT_TIMEOUT_MS=60000
+# PLAYWRIGHT_WAIT_MS=30000
 
 # Optional: Redis Cache Configuration
 # Get your Upstash Redis credentials from https://upstash.com

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,16 @@
+# Scrape provider: firecrawl (default) or playwright
+SCRAPE_PROVIDER=firecrawl
+
 # Firecrawl API Configuration
 # Get your API key from https://firecrawl.dev
-
+# Required when SCRAPE_PROVIDER=firecrawl
 FIRECRAWL_API_KEY=your_firecrawl_api_key_here
+
+# Playwright provider configuration
+# Required once per self-hosted machine when SCRAPE_PROVIDER=playwright:
+# pnpm exec playwright install chromium
+# PLAYWRIGHT_TIMEOUT_MS=60000
+# PLAYWRIGHT_WAIT_MS=30000
 
 # Optional: Vercel Configuration
 # VERCEL_URL is automatically set by Vercel during deployment

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A high-performance web service that converts JavaScript-heavy documentation site
 
 Modern documentation sites (especially Apple's) use heavy JavaScript rendering that makes content invisible to AI agents. llm.codes solves this by:
 
-- Using Firecrawl's headless browser to execute JavaScript and capture fully-rendered content
+- Using Firecrawl's hosted browser, or opt-in self-hosted Playwright, to execute JavaScript and capture fully-rendered content
 - Converting dynamic HTML to clean, semantic Markdown
 - Removing noise (navigation, footers, duplicate content) that wastes AI context tokens
 - Providing parallel URL processing for efficient multi-page documentation crawling
@@ -49,7 +49,7 @@ Experience the tool instantly without any setup required.
 
 - Node.js 24+
 - pnpm 10+
-- [Firecrawl API key](https://firecrawl.dev)
+- [Firecrawl API key](https://firecrawl.dev) for the default provider, or self-hosted Chromium for the Playwright provider
 
 ### Installation
 
@@ -72,11 +72,16 @@ pnpm install
 cp .env.local.example .env.local
 ```
 
-4. Add your Firecrawl API key to `.env.local`:
+4. Add your scrape provider configuration to `.env.local`:
 
 ```env
-# Required
+# Default hosted provider
+SCRAPE_PROVIDER=firecrawl
 FIRECRAWL_API_KEY=your_api_key_here
+
+# Self-hosted alternative
+# SCRAPE_PROVIDER=playwright
+# Run once: pnpm exec playwright install chromium
 
 # Optional - Redis Cache (Recommended for production)
 UPSTASH_REDIS_REST_URL=https://your-redis-instance.upstash.io
@@ -112,7 +117,8 @@ The easiest way to deploy is using Vercel:
 1. Push to your GitHub repository
 2. Import project on [Vercel](https://vercel.com/new)
 3. Add environment variables:
-   - `FIRECRAWL_API_KEY`: Your Firecrawl API key (required)
+   - `SCRAPE_PROVIDER`: `firecrawl` by default, or `playwright` for self-hosted Node/Docker deployments
+   - `FIRECRAWL_API_KEY`: Your Firecrawl API key (required when `SCRAPE_PROVIDER=firecrawl`)
    - `UPSTASH_REDIS_REST_URL`: Your Upstash Redis URL (optional)
    - `UPSTASH_REDIS_REST_TOKEN`: Your Upstash Redis token (optional)
    - `CACHE_ADMIN_KEY`: Admin key for cache endpoints (optional)
@@ -131,7 +137,7 @@ The easiest way to deploy is using Vercel:
    - **Deduplicate Content**: Remove duplicate paragraphs to save tokens
    - **Filter Availability**: Remove platform availability strings (iOS 14.0+, etc.)
    - **Extract Code Blocks Only**: Include fenced examples only and skip pages without examples
-   - **Use Deep Crawl Mode**: Use Firecrawl's crawl API with the selected depth and page limit
+   - **Use Deep Crawl Mode**: Use Firecrawl's crawl API with the selected depth and page limit. Turn this off when using `SCRAPE_PROVIDER=playwright`.
 
 3. **Process**: Click "Process Documentation" and grant notification permissions if prompted
 
@@ -208,7 +214,7 @@ The core API endpoint that handles documentation conversion.
 
 1. URL validation against documentation URL patterns and explicit exceptions
 2. Cache check (Redis/in-memory with 30-day TTL)
-3. Firecrawl API call with optimized scraping parameters
+3. Provider call with optimized scraping parameters. Firecrawl is the default; `SCRAPE_PROVIDER=playwright` launches self-hosted Chromium.
 4. Content post-processing and filtering
 5. Response with markdown and cache status
 
@@ -236,7 +242,7 @@ The core API endpoint that handles documentation conversion.
 **Error Handling:**
 
 - Domain validation errors (400)
-- Firecrawl API errors (500)
+- Provider/API errors (500)
 - Network timeouts (504)
 - Rate limiting (429)
 
@@ -245,7 +251,7 @@ The core API endpoint that handles documentation conversion.
 - **Framework**: [Next.js 16](https://nextjs.org/) with App Router
 - **Language**: [TypeScript](https://www.typescriptlang.org/)
 - **Styling**: [Tailwind CSS v4](https://tailwindcss.com/)
-- **API**: [Firecrawl](https://firecrawl.dev/) for web scraping
+- **API**: [Firecrawl](https://firecrawl.dev/) by default; opt-in self-hosted Playwright extraction for Node/Docker deployments
 - **Cache**: [Upstash Redis](https://upstash.com/) for distributed caching
 - **Deployment**: [Vercel](https://vercel.com/)
 - **Development**: Turbopack for fast refreshes
@@ -272,7 +278,7 @@ llm-codes/
 │   │   ├── result-processing.ts       # Final output shaping
 │   │   ├── url-utils.ts               # URL validation & handling
 │   │   └── __tests__/                 # Utility tests
-│   ├── lib/                           # Firecrawl, cache, retry, and HTTP clients
+│   ├── lib/                           # Scrape providers, cache, retry, and HTTP clients
 │   └── test/
 │       └── setup.ts                   # Test configuration
 ├── public/
@@ -298,7 +304,7 @@ llm-codes/
 
 ### Performance Optimizations
 
-- **Batched API Calls**: Reduces Firecrawl API latency by processing multiple URLs per request
+- **Batched API Calls**: Reduces provider latency by processing multiple URLs per request
 - **Progressive Loading**: UI updates with real-time progress during long crawls
 - **Smart Link Extraction**: Only follows relevant documentation links based on URL patterns
 - **Client-Side Caching**: Browser-based result caching for repeat operations
@@ -321,7 +327,7 @@ pnpm run type-check
 # Full local gate
 pnpm run verify
 
-# Live Firecrawl mode smoke without a browser
+# Live Firecrawl mode smoke without a local browser
 pnpm run verify:modes:live
 ```
 
@@ -374,11 +380,12 @@ Benefits:
 - Cache persists across deployments
 - Shared cache across all instances
 - Automatic compression for large documents
-- ~70% reduction in Firecrawl API calls
+- ~70% reduction in provider calls
 
 ### Deployment Issues?
 
-- Ensure `FIRECRAWL_API_KEY` is set in environment variables
+- Ensure `FIRECRAWL_API_KEY` is set when `SCRAPE_PROVIDER=firecrawl`
+- For `SCRAPE_PROVIDER=playwright`, run `pnpm exec playwright install chromium` on the self-hosted server
 - Check Vercel function logs for errors
 - Verify your API key is valid
 
@@ -388,11 +395,18 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Architecture Decisions
 
-### Why Firecrawl?
+### Why Firecrawl by default?
 
 - Handles JavaScript-heavy sites that traditional scrapers can't parse
 - Built-in markdown conversion with semantic structure preservation
 - Reliable headless browser automation at scale
+- Fits serverless deployments without shipping a browser binary
+
+### Why Playwright as the self-hosted alternative?
+
+- Keeps extraction in the existing Next.js app instead of adding a Python crawler or separate Firecrawl-compatible service
+- Uses a real browser for JavaScript-rendered docs and returns the same Markdown-shaped API response
+- Has one operational prerequisite: local Chromium via `pnpm exec playwright install chromium`
 
 ### Why Next.js 16 + App Router?
 
@@ -416,7 +430,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Acknowledgments
 
-- Powered by [Firecrawl](https://firecrawl.dev/referral?rid=9CG538BE) for JavaScript rendering
+- Powered by [Firecrawl](https://firecrawl.dev/referral?rid=9CG538BE) by default, with optional self-hosted Playwright rendering
 - Inspired by the challenges of making documentation accessible to AI agents
 - Built with Next.js 16, Tailwind CSS v4, and TypeScript
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-llm.codes is a Next.js application that converts JavaScript-heavy documentation sites into clean Markdown for AI consumption. The system employs a multi-layered architecture with client-side React components, server-side API routes, and a sophisticated content processing pipeline. The architecture prioritizes performance through parallel processing, caching strategies, and HTTP/2 connections.
+llm.codes is a Next.js application that converts JavaScript-heavy documentation sites into clean Markdown for AI consumption. The system employs a multi-layered architecture with client-side React components, server-side API routes, and a sophisticated content processing pipeline. The architecture prioritizes performance through parallel processing, caching strategies, HTTP/2 connections, and a small scrape-provider boundary.
 
 ## Component Map
 
@@ -16,7 +16,7 @@ llm.codes is a Next.js application that converts JavaScript-heavy documentation 
 
 **API Layer** - Next.js API routes in src/app/api/
 
-- Single URL Scraping: src/app/api/scrape/route.ts (lines 9-164)
+- Single URL Scraping: src/app/api/scrape/route.ts
 - Firecrawl Crawl Mode: src/app/api/crawl/start/route.ts and src/app/api/crawl/[jobId]/status/route.ts
 - Cache Statistics: src/app/api/cache/stats/route.ts
 
@@ -35,6 +35,8 @@ llm.codes is a Next.js application that converts JavaScript-heavy documentation 
 **Infrastructure** - Performance optimizations in src/lib/
 
 - Firecrawl Client: src/lib/firecrawl.ts owns Firecrawl request shapes, error mapping, and scrape payload validation
+- Playwright Client: src/lib/playwright-scraper.ts owns opt-in self-hosted browser extraction for `SCRAPE_PROVIDER=playwright`
+- Provider Selection: src/lib/scrape-provider.ts resolves `SCRAPE_PROVIDER` and keeps Playwright cache keys separate from Firecrawl cache keys
 - HTTP/2 Client: src/lib/http2-client.ts uses Undici agent with connection pooling
 - Constants: src/constants.ts defines all configuration (lines 1-477)
 
@@ -79,7 +81,7 @@ User enters URL → validateUrl() → isValidDocumentationUrl() checks against A
 
 ```typescript
 POST /api/scrape → Check L1/L2 cache (lines 31-46)
-→ If miss: Firecrawl API call with retries (lines 56-123)
+→ If miss: selected provider call with retries. Firecrawl is default; Playwright launches local Chromium with the requested documentation hostname pinned to a public DNS result.
 → Response validation → Cache storage → Return markdown
 ```
 
@@ -104,7 +106,7 @@ Raw markdown → filterNavigationAndUIChrome() → filterLegalBoilerplate()
 ```typescript
 Request → Check L1 memory cache (5 min TTL)
 → If miss: Check L2 Redis cache (30 day TTL)
-→ If miss: Fetch from source → Compress if >5KB
+→ If miss: Fetch from selected provider → Compress if >5KB
 → Store in both L1 and L2 → Return content
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,10 +6,10 @@ llm-codes is a Next.js 16 application optimized for serverless deployment with b
 
 ## Overview
 
-The application uses Next.js App Router with server-side rendering and API routes. Key deployment considerations include environment variables for Firecrawl API access, optional Redis caching, and function timeout configurations for long-running scraping operations.
+The application uses Next.js App Router with server-side rendering and API routes. Key deployment considerations include scrape provider selection, optional Redis caching, and function timeout configurations for long-running scraping operations.
 
 **Build Output** - Production bundle in .next/ directory, static assets in public/
-**Key Dependencies** - Node.js 24+, pnpm 10+, Firecrawl API key, optional Upstash Redis
+**Key Dependencies** - Node.js 24+, pnpm 10+, Firecrawl API key for the default provider, optional Chromium/Playwright for self-hosted extraction, optional Upstash Redis
 **Function Limits** - 60-second timeout for scraping API, configurable in vercel.json
 
 ## Package Types
@@ -40,7 +40,7 @@ pnpm run type-check
 ### Vercel (Recommended)
 
 **Configuration** - vercel.json sets 60-second timeout for API route
-**Environment** - Set FIRECRAWL_API_KEY in Vercel dashboard
+**Environment** - Set FIRECRAWL_API_KEY in Vercel dashboard. Keep `SCRAPE_PROVIDER=firecrawl` on serverless unless the platform includes a compatible browser runtime.
 **Auto-deploy** - Push to GitHub main branch triggers deployment
 
 ```bash
@@ -55,7 +55,7 @@ pnpm dlx vercel --prod
 
 **Build Settings** - Build command: `pnpm run build`, publish: `.next`
 **Functions** - Requires netlify.toml for API timeout configuration
-**Environment** - Add FIRECRAWL_API_KEY in site settings
+**Environment** - Add FIRECRAWL_API_KEY in site settings for the default provider
 
 ```toml
 # netlify.toml (create if needed)
@@ -103,8 +103,13 @@ CMD ["pnpm", "start"]
 **Required Variables** - Set in .env.local for development, platform dashboard for production
 
 ```bash
-# Firecrawl API (required)
+# Firecrawl API (required when SCRAPE_PROVIDER=firecrawl)
+SCRAPE_PROVIDER=firecrawl
 FIRECRAWL_API_KEY=your_api_key_here
+
+# Self-hosted Playwright provider
+# SCRAPE_PROVIDER=playwright
+# pnpm exec playwright install chromium
 
 # Redis Cache (optional)
 UPSTASH_REDIS_REST_URL=your_redis_url
@@ -126,7 +131,7 @@ VERCEL_URL=https://your-deployment.vercel.app
 
 **Caching Strategy** - 30-day Redis cache with LZ-string compression (redis-cache.ts lines 76-88)
 **Batch Processing** - 10 concurrent URLs per batch (constants.ts)
-**Function Timeouts** - 60 seconds for Firecrawl API calls (vercel.json line 4)
+**Function Timeouts** - 60 seconds for provider calls (vercel.json line 4)
 **Compression** - Automatic for content >5KB (redis-cache.ts line 26)
 
 ### Next.js Optimizations
@@ -184,5 +189,6 @@ curl https://your-app.vercel.app/api/scrape \
 
 **Function Timeouts** - Increase limits in vercel.json or netlify.toml
 **Redis Connection** - Check UPSTASH_REDIS_REST_URL format and token
+**Playwright Browser Missing** - Run `pnpm exec playwright install chromium` on self-hosted servers
 **Memory Issues** - Reduce BATCH_SIZE in constants.ts for large crawls
 **CORS Errors** - API routes handle CORS automatically via Next.js

--- a/docs/files.md
+++ b/docs/files.md
@@ -22,7 +22,7 @@ File organization follows Next.js App Router conventions with `src/app` for rout
 
 **Scraping Endpoints**
 
-- `src/app/api/scrape/route.ts` - Main scraping endpoint with caching, retries, and Firecrawl integration
+- `src/app/api/scrape/route.ts` - Main scraping endpoint with caching, retries, and provider selection
 - `src/app/api/crawl/start/route.ts` - Starts Firecrawl crawl jobs
 - `src/app/api/crawl/[jobId]/status/route.ts` - Streams Firecrawl crawl status and page results
 - `src/app/api/cache/stats/route.ts` - Cache statistics endpoint for monitoring
@@ -41,6 +41,8 @@ File organization follows Next.js App Router conventions with `src/app` for rout
 **Libraries**
 
 - `src/lib/firecrawl.ts` - Shared Firecrawl client, error mapping, and content validation helpers
+- `src/lib/playwright-scraper.ts` - Opt-in self-hosted Playwright renderer and Markdown extraction
+- `src/lib/scrape-provider.ts` - Provider selection, provider errors, and cache key scoping
 - `src/lib/http2-client.ts` - HTTP/2 client wrapper used by the Firecrawl client
 - `src/lib/cache/redis-cache.ts` - Redis cache implementation with TTL support
 
@@ -94,5 +96,5 @@ File organization follows Next.js App Router conventions with `src/app` for rout
 **Core Framework**: Next.js 16 with App Router, React 19, TypeScript 6
 **Styling**: Tailwind CSS v4 and custom CSS utilities
 **Testing**: Vitest with happy-dom, coverage reporting, and optional live Firecrawl smoke scripts
-**External APIs**: Firecrawl for JavaScript rendering
+**External APIs**: Firecrawl by default; optional self-hosted Playwright browser extraction
 **Caching**: In-memory with optional Redis support

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -36,7 +36,7 @@ llm.codes is a high-performance web service that converts JavaScript-heavy docum
 
 **API & Processing**:
 
-- Firecrawl API for JavaScript rendering - `src/app/api/scrape/route.ts` (lines 65-83)
+- Firecrawl API by default, or opt-in self-hosted Playwright browser extraction - `src/app/api/scrape/route.ts`
 - HTTP/2 client for performance - `src/lib/http2-client.ts`
 - Content filtering pipeline - `src/utils/content-processing.ts`, `src/utils/documentation-filter.ts`
 
@@ -58,7 +58,8 @@ llm.codes is a high-performance web service that converts JavaScript-heavy docum
 
 - Node.js 24.0+ - `package.json` (`"engines": { "node": ">=24.0.0" }`)
 - Modern browsers with Notification API support
-- Firecrawl API key (required) - Environment variable `FIRECRAWL_API_KEY`
+- Firecrawl API key for the default provider - Environment variable `FIRECRAWL_API_KEY`
+- Self-hosted Playwright provider - Environment variable `SCRAPE_PROVIDER=playwright`; install Chromium with `pnpm exec playwright install chromium`
 - Upstash Redis (optional) - Environment variables `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
 
 **Deployment Platforms**:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,7 @@ Testing approach: Unit tests for utilities and components, integration tests for
 - Main scrape endpoint: `src/app/api/scrape/__tests__/route.test.ts`
 - Crawl endpoints: `src/app/api/crawl/**/__tests__/route.test.ts`
 - Firecrawl client: `src/lib/__tests__/firecrawl.test.ts`
+- Provider selection: `src/lib/__tests__/scrape-provider.test.ts`
 - Redis cache: `src/lib/cache/__tests__/redis-cache.test.ts`
 
 **Component Tests** - React components using Testing Library (when present)
@@ -51,6 +52,10 @@ scrapes `/llms.txt` when discovered.
 code block extraction against several real docs sites, starts a small Firecrawl crawl with
 `limit=3` and `maxDepth=1`, and reads the SSE status stream until completion. It is the CLI
 replacement for manually opening the browser to prove the optional processing modes still work.
+
+For Playwright provider checks, set `SCRAPE_PROVIDER=playwright` and run
+`pnpm exec playwright install chromium` once on the self-hosted machine. Deep crawl mode remains
+Firecrawl-only; use the standard recursive client processing path for Playwright-backed extraction.
 
 **Test Environment Setup** - Global configuration in **src/test/setup.ts**:
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@vercel/analytics": "^2.0.1",
     "lz-string": "^1.5.0",
     "next": "16.2.6",
+    "playwright": "^1.60.0",
     "postcss": "^8.5.14",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       next:
         specifier: 16.2.6
         version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       postcss:
         specifier: ^8.5.14
         version: 8.5.14
@@ -1094,6 +1097,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1288,6 +1296,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2203,6 +2221,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2393,6 +2414,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:

--- a/src/app/api/crawl/[jobId]/status/__tests__/route.test.ts
+++ b/src/app/api/crawl/[jobId]/status/__tests__/route.test.ts
@@ -88,6 +88,45 @@ describe("GET /api/crawl/[jobId]/status", () => {
     expect(http2Fetch).toHaveBeenCalled();
   });
 
+  it("trims the Firecrawl API key before polling crawl status", async () => {
+    process.env.FIRECRAWL_API_KEY = "  test-api-key  ";
+    vi.mocked(cacheService.getCrawlJob).mockResolvedValue({
+      id: mockJobId,
+      url: "https://example.com",
+      limit: 10,
+      startedAt: new Date().toISOString(),
+      status: "scraping",
+      totalPages: 0,
+      completedPages: 0,
+      creditsUsed: 0,
+    });
+    vi.mocked(http2Fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        status: "completed",
+        total: 0,
+        completed: 0,
+        creditsUsed: 0,
+        data: [],
+      }),
+    } as unknown as Response);
+    vi.mocked(cacheService.updateCrawlJobStatus).mockResolvedValue();
+    vi.mocked(cacheService.setCrawlResults).mockResolvedValue();
+
+    const response = await GET(mockRequest, { params: mockParams });
+    await response.body?.getReader().read();
+
+    expect(http2Fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-api-key",
+        }),
+      }),
+    );
+  });
+
   it("should log 502 errors without sending them to client", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error");
 

--- a/src/app/api/crawl/[jobId]/status/route.ts
+++ b/src/app/api/crawl/[jobId]/status/route.ts
@@ -28,7 +28,7 @@ export async function GET(
   };
 
   try {
-    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
+    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY?.trim();
     if (!FIRECRAWL_API_KEY) {
       return new Response(
         encoder.encode(

--- a/src/app/api/crawl/start/__tests__/route.test.ts
+++ b/src/app/api/crawl/start/__tests__/route.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/utils/url-utils", () => ({
 describe("POST /api/crawl/start", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.SCRAPE_PROVIDER;
     process.env.FIRECRAWL_API_KEY = "test-api-key";
   });
 
@@ -154,6 +155,29 @@ describe("POST /api/crawl/start", () => {
     expect(response.status).toBe(503);
     expect(data.error).toContain("temporarily unavailable");
     expect(data.circuitBreaker).toBe("open");
+  });
+
+  it("rejects deep crawl mode when Playwright is the scrape provider", async () => {
+    const { isValidDocumentationUrl } = await import("@/utils/url-utils");
+    const { http2Fetch } = await import("@/lib/http2-client");
+
+    process.env.SCRAPE_PROVIDER = "playwright";
+    (isValidDocumentationUrl as Mock).mockReturnValue(true);
+
+    const request = new NextRequest("http://localhost:3000/api/crawl/start", {
+      method: "POST",
+      body: JSON.stringify({
+        url: "https://docs.example.com",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(data.provider).toBe("playwright");
+    expect(data.error).toContain("Deep crawl mode requires SCRAPE_PROVIDER=firecrawl");
+    expect(http2Fetch).not.toHaveBeenCalled();
   });
 
   it("should handle API errors", async () => {

--- a/src/app/api/crawl/start/__tests__/route.test.ts
+++ b/src/app/api/crawl/start/__tests__/route.test.ts
@@ -180,6 +180,28 @@ describe("POST /api/crawl/start", () => {
     expect(http2Fetch).not.toHaveBeenCalled();
   });
 
+  it("surfaces unsupported scrape provider configuration errors", async () => {
+    const { isValidDocumentationUrl } = await import("@/utils/url-utils");
+    const { http2Fetch } = await import("@/lib/http2-client");
+
+    process.env.SCRAPE_PROVIDER = "invalid-provider";
+    (isValidDocumentationUrl as Mock).mockReturnValue(true);
+
+    const request = new NextRequest("http://localhost:3000/api/crawl/start", {
+      method: "POST",
+      body: JSON.stringify({
+        url: "https://docs.example.com",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toContain('Unsupported SCRAPE_PROVIDER "invalid-provider"');
+    expect(http2Fetch).not.toHaveBeenCalled();
+  });
+
   it("should handle API errors", async () => {
     const { isValidDocumentationUrl } = await import("@/utils/url-utils");
     const { http2Fetch } = await import("@/lib/http2-client");
@@ -224,5 +246,27 @@ describe("POST /api/crawl/start", () => {
 
     expect(response.status).toBe(500);
     expect(data.error).toContain("Server configuration error");
+  });
+
+  it("rejects whitespace-only API keys before calling Firecrawl", async () => {
+    const { isValidDocumentationUrl } = await import("@/utils/url-utils");
+    const { http2Fetch } = await import("@/lib/http2-client");
+
+    process.env.FIRECRAWL_API_KEY = "   ";
+    (isValidDocumentationUrl as Mock).mockReturnValue(true);
+
+    const request = new NextRequest("http://localhost:3000/api/crawl/start", {
+      method: "POST",
+      body: JSON.stringify({
+        url: "https://docs.example.com",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toContain("Server configuration error");
+    expect(http2Fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/crawl/start/route.ts
+++ b/src/app/api/crawl/start/route.ts
@@ -3,6 +3,7 @@ import { isValidDocumentationUrl } from "@/utils/url-utils";
 import { PROCESSING_CONFIG } from "@/constants";
 import { cacheService } from "@/lib/cache/redis-cache";
 import { FirecrawlRequestError, startFirecrawlCrawl } from "@/lib/firecrawl";
+import { resolveScrapeProvider, ScrapeProviderConfigError } from "@/lib/scrape-provider";
 
 function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
   const parsed = typeof value === "number" ? value : Number.parseInt(String(value), 10);
@@ -12,14 +13,9 @@ function clampInteger(value: unknown, fallback: number, min: number, max: number
 
 export async function POST(request: NextRequest) {
   try {
-    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
-
-    if (!FIRECRAWL_API_KEY) {
-      return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
-    }
-
     const body = await request.json();
     const { url } = body;
+    const provider = resolveScrapeProvider();
 
     const enforcedLimit = clampInteger(body.limit, 10, 1, PROCESSING_CONFIG.MAX_ALLOWED_URLS);
     const enforcedMaxDepth = clampInteger(
@@ -35,6 +31,29 @@ export async function POST(request: NextRequest) {
           error: "Invalid URL. Must be from an allowed documentation domain",
         },
         { status: 400 },
+      );
+    }
+
+    if (provider !== "firecrawl") {
+      return NextResponse.json(
+        {
+          error:
+            "Deep crawl mode requires SCRAPE_PROVIDER=firecrawl. Turn off deep crawl mode to use the Playwright scrape provider.",
+          provider,
+        },
+        { status: 501 },
+      );
+    }
+
+    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
+
+    if (!FIRECRAWL_API_KEY) {
+      return NextResponse.json(
+        {
+          error:
+            "Server configuration error: FIRECRAWL_API_KEY is required when SCRAPE_PROVIDER=firecrawl.",
+        },
+        { status: 500 },
       );
     }
 
@@ -111,6 +130,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: `Network error: ${errorMessage}` }, { status: 500 });
     }
   } catch (error) {
+    if (error instanceof ScrapeProviderConfigError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
     console.error("Crawl Start API Error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/src/app/api/crawl/start/route.ts
+++ b/src/app/api/crawl/start/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
+    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY?.trim();
 
     if (!FIRECRAWL_API_KEY) {
       return NextResponse.json(

--- a/src/app/api/scrape/__tests__/route.test.ts
+++ b/src/app/api/scrape/__tests__/route.test.ts
@@ -230,6 +230,31 @@ describe("POST /api/scrape", () => {
     expect(scrapeFirecrawlUrl).not.toHaveBeenCalled();
   });
 
+  it("deletes incomplete cache after lock wait and scrapes fresh content", async () => {
+    vi.mocked(cacheService.acquireLock).mockResolvedValue(null);
+    vi.mocked(cacheService.waitForLock).mockResolvedValue(true);
+    vi.mocked(cacheService.get)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("[Skip Navigation](#main)");
+    vi.mocked(scrapeFirecrawlUrl).mockResolvedValue({
+      success: true,
+      data: { markdown: "# Fresh after wait\n\n" + "content ".repeat(80) },
+    });
+
+    const response = await POST(
+      scrapeRequest({ url: "https://developer.apple.com/documentation/swiftui" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(false);
+    expect(data.data.markdown).toContain("# Fresh after wait");
+    expect(cacheService.delete).toHaveBeenCalledWith(
+      "https://developer.apple.com/documentation/swiftui",
+    );
+    expect(scrapeFirecrawlUrl).toHaveBeenCalledTimes(1);
+  });
+
   it("retries incomplete Firecrawl content before succeeding", async () => {
     vi.mocked(scrapeFirecrawlUrl)
       .mockResolvedValueOnce({ success: true, data: { markdown: "Loading..." } })

--- a/src/app/api/scrape/__tests__/route.test.ts
+++ b/src/app/api/scrape/__tests__/route.test.ts
@@ -73,6 +73,62 @@ describe("POST /api/scrape", () => {
     expect(scrapeFirecrawlUrl).not.toHaveBeenCalled();
   });
 
+  it("returns stored metadata on cache hits", async () => {
+    vi.mocked(cacheService.get).mockResolvedValue(
+      JSON.stringify({
+        cacheVersion: 1,
+        markdown: "# Cached\n\n" + "content ".repeat(80),
+        metadata: {
+          sourceURL: "https://developer.apple.com/documentation/swiftui/view",
+          url: "https://developer.apple.com/documentation/swiftui/view",
+          title: "View | Apple Developer Documentation",
+          provider: "playwright",
+          status: 200,
+        },
+      }),
+    );
+
+    process.env.SCRAPE_PROVIDER = "playwright";
+
+    const response = await POST(
+      scrapeRequest({ url: "https://developer.apple.com/documentation/swiftui" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(true);
+    expect(data.data.markdown).toContain("# Cached");
+    expect(data.data.metadata).toEqual(
+      expect.objectContaining({
+        sourceURL: "https://developer.apple.com/documentation/swiftui/view",
+        url: "https://developer.apple.com/documentation/swiftui/view",
+        title: "View | Apple Developer Documentation",
+        provider: "playwright",
+        status: 200,
+        cached: true,
+      }),
+    );
+    expect(scrapePlaywrightUrl).not.toHaveBeenCalled();
+  });
+
+  it("keeps Firecrawl cache hits as raw markdown even when they look like JSON payloads", async () => {
+    const rawMarkdown = JSON.stringify({
+      cacheVersion: 1,
+      markdown: "# Inner markdown that should not replace the raw Firecrawl cache",
+    });
+    vi.mocked(cacheService.get).mockResolvedValue(rawMarkdown);
+
+    const response = await POST(
+      scrapeRequest({ url: "https://developer.apple.com/documentation/swiftui" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(true);
+    expect(data.data.markdown).toBe(rawMarkdown);
+    expect(scrapeFirecrawlUrl).not.toHaveBeenCalled();
+  });
+
   it("uses Playwright without a Firecrawl key when configured", async () => {
     process.env.SCRAPE_PROVIDER = "playwright";
     delete process.env.FIRECRAWL_API_KEY;
@@ -190,6 +246,10 @@ describe("POST /api/scrape", () => {
     expect(response.status).toBe(200);
     expect(data.retriesUsed).toBe(1);
     expect(scrapeFirecrawlUrl).toHaveBeenCalledTimes(2);
+    expect(cacheService.set).toHaveBeenCalledWith(
+      "https://developer.apple.com/documentation/swiftui",
+      "# Complete\n\n" + "content ".repeat(80),
+    );
     expect(cacheService.firecrawlCircuitBreaker.recordSuccess).toHaveBeenCalled();
   });
 
@@ -211,6 +271,25 @@ describe("POST /api/scrape", () => {
     );
   });
 
+  it("trims the Firecrawl API key before scraping", async () => {
+    process.env.FIRECRAWL_API_KEY = "  test-api-key  ";
+    vi.mocked(scrapeFirecrawlUrl).mockResolvedValue({
+      success: true,
+      data: { markdown: "# Complete\n\n" + "content ".repeat(80) },
+    });
+
+    const response = await POST(
+      scrapeRequest({ url: "https://developer.apple.com/documentation/swiftui" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(scrapeFirecrawlUrl).toHaveBeenCalledWith(
+      "test-api-key",
+      "https://developer.apple.com/documentation/swiftui",
+      expect.any(Object),
+    );
+  });
+
   it("fails fast when the circuit breaker is open", async () => {
     vi.mocked(cacheService.firecrawlCircuitBreaker.canRequest).mockResolvedValue(false);
 
@@ -221,6 +300,7 @@ describe("POST /api/scrape", () => {
 
     expect(response.status).toBe(503);
     expect(data.circuitBreaker).toBe("open");
+    expect(data.provider).toBe("firecrawl");
     expect(scrapeFirecrawlUrl).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/scrape/__tests__/route.test.ts
+++ b/src/app/api/scrape/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 import { POST } from "../route";
 import { cacheService } from "@/lib/cache/redis-cache";
 import { scrapeFirecrawlUrl } from "@/lib/firecrawl";
+import { scrapePlaywrightUrl } from "@/lib/playwright-scraper";
 
 vi.mock("@/lib/cache/redis-cache", () => ({
   cacheService: {
@@ -29,6 +30,14 @@ vi.mock("@/lib/firecrawl", async (importOriginal) => {
   };
 });
 
+vi.mock("@/lib/playwright-scraper", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/playwright-scraper")>();
+  return {
+    ...actual,
+    scrapePlaywrightUrl: vi.fn(),
+  };
+});
+
 function scrapeRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost:3000/api/scrape", {
     method: "POST",
@@ -39,6 +48,8 @@ function scrapeRequest(body: Record<string, unknown>) {
 describe("POST /api/scrape", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.SCRAPE_PROVIDER;
+    delete process.env.PLAYWRIGHT_WS_ENDPOINT;
     process.env.FIRECRAWL_API_KEY = "test-api-key";
     vi.mocked(cacheService.get).mockResolvedValue(null);
     vi.mocked(cacheService.acquireLock).mockResolvedValue("lock-1");
@@ -60,6 +71,66 @@ describe("POST /api/scrape", () => {
     expect(response.status).toBe(200);
     expect(data.cached).toBe(true);
     expect(scrapeFirecrawlUrl).not.toHaveBeenCalled();
+  });
+
+  it("uses Playwright without a Firecrawl key when configured", async () => {
+    process.env.SCRAPE_PROVIDER = "playwright";
+    delete process.env.FIRECRAWL_API_KEY;
+    vi.mocked(scrapePlaywrightUrl).mockResolvedValue({
+      success: true,
+      data: {
+        markdown: "# Playwright Docs\n\n" + "rendered content ".repeat(40),
+        metadata: {
+          sourceURL: "https://developer.apple.com/documentation/swiftui",
+          provider: "playwright",
+        },
+      },
+    });
+
+    const response = await POST(
+      scrapeRequest({ url: "https://developer.apple.com/documentation/swiftui" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.provider).toBe("playwright");
+    expect(scrapePlaywrightUrl).toHaveBeenCalledWith(
+      "https://developer.apple.com/documentation/swiftui",
+      expect.objectContaining({ waitFor: expect.any(Number), timeout: expect.any(Number) }),
+    );
+    expect(scrapeFirecrawlUrl).not.toHaveBeenCalled();
+    expect(cacheService.firecrawlCircuitBreaker.canRequest).not.toHaveBeenCalled();
+  });
+
+  it("uses provider-scoped cache keys for Playwright", async () => {
+    process.env.SCRAPE_PROVIDER = "playwright";
+    vi.mocked(cacheService.get).mockResolvedValue("# Cached\n\n" + "content ".repeat(80));
+
+    const response = await POST(
+      scrapeRequest({ url: "https://developer.apple.com/documentation/swiftui" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cached).toBe(true);
+    expect(cacheService.get).toHaveBeenCalledWith(
+      "playwright:https://developer.apple.com/documentation/swiftui",
+    );
+    expect(scrapePlaywrightUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error for an unsupported scrape provider", async () => {
+    process.env.SCRAPE_PROVIDER = "crawl4ai";
+
+    const response = await POST(
+      scrapeRequest({ url: "https://developer.apple.com/documentation/swiftui" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toContain('Unsupported SCRAPE_PROVIDER "crawl4ai"');
+    expect(scrapeFirecrawlUrl).not.toHaveBeenCalled();
+    expect(scrapePlaywrightUrl).not.toHaveBeenCalled();
   });
 
   it("deletes incomplete cached content and refreshes it", async () => {

--- a/src/app/api/scrape/route.ts
+++ b/src/app/api/scrape/route.ts
@@ -14,8 +14,22 @@ import {
   getProviderCacheKey,
   getProviderName,
   resolveScrapeProvider,
+  ScrapeProvider,
   ScrapeProviderConfigError,
 } from "@/lib/scrape-provider";
+
+interface CachedScrapePayload {
+  cacheVersion: 1;
+  markdown: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface DecodedCachedScrape {
+  markdown: string;
+  metadata: Record<string, unknown>;
+}
+
+const SCRAPE_CACHE_VERSION = 1;
 
 export async function POST(request: NextRequest) {
   let action: string | undefined;
@@ -41,15 +55,22 @@ export async function POST(request: NextRequest) {
       // Check cache first
       const cached = await cacheService.get(cacheKey);
       if (cached) {
-        if (getIncompleteContentReason(cached)) {
+        const cachedScrape =
+          provider === "playwright"
+            ? decodeCachedScrape(cached, provider, url)
+            : decodeLegacyCachedScrape(cached, provider, url);
+
+        if (getIncompleteContentReason(cachedScrape.markdown)) {
           await cacheService.delete(cacheKey);
-          console.warn(`Removed truncated cached content for ${url} (${cached.length} chars)`);
+          console.warn(
+            `Removed truncated cached content for ${url} (${cachedScrape.markdown.length} chars)`,
+          );
         } else {
           return NextResponse.json({
             success: true,
             data: {
-              markdown: cached,
-              metadata: { sourceURL: url, url, provider, cached: true },
+              markdown: cachedScrape.markdown,
+              metadata: cachedScrape.metadata,
             },
             cached: true,
             provider,
@@ -72,11 +93,15 @@ export async function POST(request: NextRequest) {
           // Check cache again - the other process should have populated it
           const cachedAfterWait = await cacheService.get(cacheKey);
           if (cachedAfterWait) {
+            const cachedScrape =
+              provider === "playwright"
+                ? decodeCachedScrape(cachedAfterWait, provider, url)
+                : decodeLegacyCachedScrape(cachedAfterWait, provider, url);
             return NextResponse.json({
               success: true,
               data: {
-                markdown: cachedAfterWait,
-                metadata: { sourceURL: url, url, provider, cached: true },
+                markdown: cachedScrape.markdown,
+                metadata: cachedScrape.metadata,
               },
               cached: true,
               waitedForLock: true,
@@ -91,7 +116,7 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
+        const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY?.trim();
 
         if (provider === "firecrawl") {
           if (!FIRECRAWL_API_KEY) {
@@ -114,6 +139,7 @@ export async function POST(request: NextRequest) {
                 error: "Documentation service is temporarily unavailable",
                 details:
                   "The service is experiencing high failure rates. Please try again in a minute.",
+                provider,
                 circuitBreaker: "open",
               },
               { status: 503 },
@@ -173,7 +199,15 @@ export async function POST(request: NextRequest) {
             }
 
             if (isCacheableFirecrawlContent(markdown)) {
-              await cacheService.set(cacheKey, markdown);
+              await cacheService.set(
+                cacheKey,
+                provider === "playwright"
+                  ? encodeCachedScrape(
+                      markdown,
+                      buildScrapeMetadata(data.data?.metadata, provider, url, false),
+                    )
+                  : markdown,
+              );
             } else {
               console.warn(`Content for ${url} is short (${markdown.length} chars) but proceeding`);
             }
@@ -185,7 +219,10 @@ export async function POST(request: NextRequest) {
 
             return NextResponse.json({
               success: true,
-              data: { markdown, metadata: data.data?.metadata },
+              data: {
+                markdown,
+                metadata: buildScrapeMetadata(data.data?.metadata, provider, url, false),
+              },
               cached: false,
               provider,
               retriesUsed: attempt,
@@ -286,4 +323,62 @@ export async function POST(request: NextRequest) {
       // Stats available via cacheService.getStats()
     }
   }
+}
+
+function encodeCachedScrape(markdown: string, metadata: Record<string, unknown>): string {
+  const payload: CachedScrapePayload = {
+    cacheVersion: SCRAPE_CACHE_VERSION,
+    markdown,
+    metadata,
+  };
+  return JSON.stringify(payload);
+}
+
+function decodeCachedScrape(
+  cached: string,
+  provider: ScrapeProvider,
+  requestedUrl: string,
+): DecodedCachedScrape {
+  try {
+    const parsed = JSON.parse(cached) as Partial<CachedScrapePayload>;
+    if (parsed.cacheVersion === SCRAPE_CACHE_VERSION && typeof parsed.markdown === "string") {
+      return {
+        markdown: parsed.markdown,
+        metadata: buildScrapeMetadata(parsed.metadata, provider, requestedUrl, true),
+      };
+    }
+  } catch {
+    // Legacy cache entries are raw markdown strings.
+  }
+
+  return {
+    markdown: cached,
+    metadata: buildScrapeMetadata(undefined, provider, requestedUrl, true),
+  };
+}
+
+function decodeLegacyCachedScrape(
+  cached: string,
+  provider: ScrapeProvider,
+  requestedUrl: string,
+): DecodedCachedScrape {
+  return {
+    markdown: cached,
+    metadata: buildScrapeMetadata(undefined, provider, requestedUrl, true),
+  };
+}
+
+function buildScrapeMetadata(
+  metadata: Record<string, unknown> | undefined,
+  provider: ScrapeProvider,
+  requestedUrl: string,
+  cached: boolean,
+): Record<string, unknown> {
+  return {
+    sourceURL: requestedUrl,
+    url: requestedUrl,
+    ...metadata,
+    provider,
+    cached,
+  };
 }

--- a/src/app/api/scrape/route.ts
+++ b/src/app/api/scrape/route.ts
@@ -97,17 +97,24 @@ export async function POST(request: NextRequest) {
               provider === "playwright"
                 ? decodeCachedScrape(cachedAfterWait, provider, url)
                 : decodeLegacyCachedScrape(cachedAfterWait, provider, url);
-            return NextResponse.json({
-              success: true,
-              data: {
-                markdown: cachedScrape.markdown,
-                metadata: cachedScrape.metadata,
-              },
-              cached: true,
-              waitedForLock: true,
-              provider,
-              codeBlocksOnly, // Pass through the parameter
-            });
+            if (getIncompleteContentReason(cachedScrape.markdown)) {
+              await cacheService.delete(cacheKey);
+              console.warn(
+                `Removed truncated cached content for ${url} after lock wait (${cachedScrape.markdown.length} chars)`,
+              );
+            } else {
+              return NextResponse.json({
+                success: true,
+                data: {
+                  markdown: cachedScrape.markdown,
+                  metadata: cachedScrape.metadata,
+                },
+                cached: true,
+                waitedForLock: true,
+                provider,
+                codeBlocksOnly, // Pass through the parameter
+              });
+            }
           }
         }
 
@@ -291,6 +298,7 @@ export async function POST(request: NextRequest) {
               suggestion:
                 "Please try again in a few moments. The server may be experiencing high load.",
               attempts: MAX_RETRIES + 1,
+              provider,
             },
             { status: 500 },
           );

--- a/src/app/api/scrape/route.ts
+++ b/src/app/api/scrape/route.ts
@@ -9,20 +9,24 @@ import {
   readFirecrawlMarkdown,
   scrapeFirecrawlUrl,
 } from "@/lib/firecrawl";
+import { PlaywrightRequestError, scrapePlaywrightUrl } from "@/lib/playwright-scraper";
+import {
+  getProviderCacheKey,
+  getProviderName,
+  resolveScrapeProvider,
+  ScrapeProviderConfigError,
+} from "@/lib/scrape-provider";
 
 export async function POST(request: NextRequest) {
   let action: string | undefined;
 
   try {
-    const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
-
-    if (!FIRECRAWL_API_KEY) {
-      return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
-    }
-
     const body = await request.json();
     const { url, codeBlocksOnly = false } = body;
     action = body.action;
+    const provider = resolveScrapeProvider();
+    const providerName = getProviderName(provider);
+    const cacheKey = getProviderCacheKey(provider, url);
 
     if (!isValidDocumentationUrl(url)) {
       return NextResponse.json(
@@ -35,40 +39,48 @@ export async function POST(request: NextRequest) {
 
     if (action === "scrape") {
       // Check cache first
-      const cached = await cacheService.get(url);
+      const cached = await cacheService.get(cacheKey);
       if (cached) {
         if (getIncompleteContentReason(cached)) {
-          await cacheService.delete(url);
+          await cacheService.delete(cacheKey);
           console.warn(`Removed truncated cached content for ${url} (${cached.length} chars)`);
         } else {
           return NextResponse.json({
             success: true,
-            data: { markdown: cached },
+            data: {
+              markdown: cached,
+              metadata: { sourceURL: url, url, provider, cached: true },
+            },
             cached: true,
+            provider,
             codeBlocksOnly, // Pass through the parameter
           });
         }
       }
 
       // Try to acquire lock for this URL
-      const lockId = await cacheService.acquireLock(url);
+      const lockId = await cacheService.acquireLock(cacheKey);
 
       if (!lockId) {
         // Another process is already scraping this URL
         console.warn(`URL ${url} is already being processed, waiting for completion...`);
 
         // Wait for the lock to be released
-        const lockReleased = await cacheService.waitForLock(url);
+        const lockReleased = await cacheService.waitForLock(cacheKey);
 
         if (lockReleased) {
           // Check cache again - the other process should have populated it
-          const cachedAfterWait = await cacheService.get(url);
+          const cachedAfterWait = await cacheService.get(cacheKey);
           if (cachedAfterWait) {
             return NextResponse.json({
               success: true,
-              data: { markdown: cachedAfterWait },
+              data: {
+                markdown: cachedAfterWait,
+                metadata: { sourceURL: url, url, provider, cached: true },
+              },
               cached: true,
               waitedForLock: true,
+              provider,
               codeBlocksOnly, // Pass through the parameter
             });
           }
@@ -79,20 +91,34 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        // Check circuit breaker before attempting to scrape
-        const canRequest = await cacheService.firecrawlCircuitBreaker.canRequest();
+        const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
 
-        if (!canRequest) {
-          console.error(`Circuit breaker is OPEN for Firecrawl API, failing fast for ${url}`);
-          return NextResponse.json(
-            {
-              error: "Documentation service is temporarily unavailable",
-              details:
-                "The service is experiencing high failure rates. Please try again in a minute.",
-              circuitBreaker: "open",
-            },
-            { status: 503 },
-          );
+        if (provider === "firecrawl") {
+          if (!FIRECRAWL_API_KEY) {
+            return NextResponse.json(
+              {
+                error:
+                  "Server configuration error: FIRECRAWL_API_KEY is required when SCRAPE_PROVIDER=firecrawl.",
+              },
+              { status: 500 },
+            );
+          }
+
+          // Check circuit breaker before attempting to scrape
+          const canRequest = await cacheService.firecrawlCircuitBreaker.canRequest();
+
+          if (!canRequest) {
+            console.error(`Circuit breaker is OPEN for Firecrawl API, failing fast for ${url}`);
+            return NextResponse.json(
+              {
+                error: "Documentation service is temporarily unavailable",
+                details:
+                  "The service is experiencing high failure rates. Please try again in a minute.",
+                circuitBreaker: "open",
+              },
+              { status: 503 },
+            );
+          }
         }
 
         const { MAX_RETRIES, INITIAL_RETRY_DELAY, MAX_RETRY_DELAY, RETRY_STATUS_CODES } =
@@ -113,11 +139,17 @@ export async function POST(request: NextRequest) {
           }
 
           try {
-            const data = await scrapeFirecrawlUrl(FIRECRAWL_API_KEY, url, {
-              formats: ["markdown"],
-              waitFor: PROCESSING_CONFIG.FIRECRAWL_WAIT_TIME,
-              timeout: PROCESSING_CONFIG.FIRECRAWL_TIMEOUT,
-            });
+            const data =
+              provider === "firecrawl"
+                ? await scrapeFirecrawlUrl(FIRECRAWL_API_KEY!, url, {
+                    formats: ["markdown"],
+                    waitFor: PROCESSING_CONFIG.FIRECRAWL_WAIT_TIME,
+                    timeout: PROCESSING_CONFIG.FIRECRAWL_TIMEOUT,
+                  })
+                : await scrapePlaywrightUrl(url, {
+                    waitFor: PROCESSING_CONFIG.FIRECRAWL_WAIT_TIME,
+                    timeout: PROCESSING_CONFIG.FIRECRAWL_TIMEOUT,
+                  });
 
             const markdown = readFirecrawlMarkdown(data);
             const incompleteReason = getIncompleteContentReason(markdown);
@@ -141,32 +173,44 @@ export async function POST(request: NextRequest) {
             }
 
             if (isCacheableFirecrawlContent(markdown)) {
-              await cacheService.set(url, markdown);
+              await cacheService.set(cacheKey, markdown);
             } else {
               console.warn(`Content for ${url} is short (${markdown.length} chars) but proceeding`);
             }
 
-            await cacheService.firecrawlCircuitBreaker.recordSuccess();
-            cacheService.incrementFirecrawlFetches();
+            if (provider === "firecrawl") {
+              await cacheService.firecrawlCircuitBreaker.recordSuccess();
+              cacheService.incrementFirecrawlFetches();
+            }
 
             return NextResponse.json({
               success: true,
-              data: { markdown },
+              data: { markdown, metadata: data.data?.metadata },
               cached: false,
+              provider,
               retriesUsed: attempt,
               contentLength: markdown.length,
               codeBlocksOnly,
             });
           } catch (error) {
-            if (error instanceof FirecrawlRequestError) {
+            if (error instanceof FirecrawlRequestError || error instanceof PlaywrightRequestError) {
               lastError = error.message;
               lastStatus = error.status;
+              const retryable =
+                error instanceof FirecrawlRequestError
+                  ? RETRY_STATUS_CODES.includes(error.status)
+                  : error.retryable;
 
-              if (!RETRY_STATUS_CODES.includes(error.status) || attempt === MAX_RETRIES) {
-                if (RETRY_STATUS_CODES.includes(error.status)) {
+              if (!retryable || attempt === MAX_RETRIES) {
+                if (provider === "firecrawl" && retryable) {
                   await cacheService.firecrawlCircuitBreaker.recordFailure();
                 }
-                return NextResponse.json({ error: error.message }, { status: error.status });
+                const errorResponse: { error: string; provider: string; details?: unknown } = {
+                  error: error.message,
+                  provider,
+                };
+                if (error.details) errorResponse.details = error.details;
+                return NextResponse.json(errorResponse, { status: error.status });
               }
               continue;
             }
@@ -176,10 +220,18 @@ export async function POST(request: NextRequest) {
 
             if (attempt === MAX_RETRIES) {
               // Record failure in circuit breaker
-              await cacheService.firecrawlCircuitBreaker.recordFailure();
-              console.error(`Failed to scrape ${url} after ${MAX_RETRIES + 1} attempts:`, error);
+              if (provider === "firecrawl") {
+                await cacheService.firecrawlCircuitBreaker.recordFailure();
+              }
+              console.error(
+                `Failed to scrape ${url} with ${providerName} after ${MAX_RETRIES + 1} attempts:`,
+                error,
+              );
               return NextResponse.json(
-                { error: `Network error after ${MAX_RETRIES + 1} attempts: ${lastError}` },
+                {
+                  error: `Network error after ${MAX_RETRIES + 1} attempts: ${lastError}`,
+                  provider,
+                },
                 { status: 500 },
               );
             }
@@ -188,7 +240,9 @@ export async function POST(request: NextRequest) {
 
         // If we got here, all retries failed
         // Record failure in circuit breaker
-        await cacheService.firecrawlCircuitBreaker.recordFailure();
+        if (provider === "firecrawl") {
+          await cacheService.firecrawlCircuitBreaker.recordFailure();
+        }
 
         // Provide helpful error message for truncated content
         if (lastError?.includes("Truncated content")) {
@@ -206,19 +260,23 @@ export async function POST(request: NextRequest) {
         }
 
         return NextResponse.json(
-          { error: lastError || "Failed to scrape after multiple attempts" },
+          { error: lastError || "Failed to scrape after multiple attempts", provider },
           { status: lastStatus || 500 },
         );
       } finally {
         // Always release the lock if we acquired one
         if (lockId) {
-          await cacheService.releaseLock(url, lockId);
+          await cacheService.releaseLock(cacheKey, lockId);
         }
       }
     }
 
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });
   } catch (error) {
+    if (error instanceof ScrapeProviderConfigError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+
     console.error("API Error:", error);
     // Cache statistics logged even on error
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/lib/__tests__/playwright-scraper.test.ts
+++ b/src/lib/__tests__/playwright-scraper.test.ts
@@ -15,6 +15,7 @@ vi.mock("node:dns/promises", () => ({
 
 describe("playwright-scraper navigation policy", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     lookupMock.mockReset();
   });
 
@@ -100,5 +101,47 @@ describe("playwright-scraper navigation policy", () => {
     await expect(
       isAllowedPlaywrightNetworkUrl("https://cdn.example.com/app.js", false),
     ).resolves.toBe(true);
+  });
+
+  it("refreshes DNS pinning after the cache TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+
+    await expect(
+      isAllowedPlaywrightNetworkUrl("https://docs.example-cache-ttl.com/", true),
+    ).resolves.toBe(true);
+    await expect(
+      isAllowedPlaywrightNetworkUrl("https://docs.example-cache-ttl.com/", true),
+    ).resolves.toBe(true);
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-01-01T00:05:01Z"));
+
+    await expect(
+      isAllowedPlaywrightNetworkUrl("https://docs.example-cache-ttl.com/", true),
+    ).resolves.toBe(true);
+    expect(lookupMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("negative-caches rejected DNS lookups briefly", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    lookupMock.mockRejectedValue(new Error("temporary DNS failure"));
+
+    await expect(
+      isAllowedPlaywrightNetworkUrl("https://docs.example-negative-cache.com/", true),
+    ).resolves.toBe(false);
+    await expect(
+      isAllowedPlaywrightNetworkUrl("https://docs.example-negative-cache.com/", true),
+    ).resolves.toBe(false);
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:31Z"));
+
+    await expect(
+      isAllowedPlaywrightNetworkUrl("https://docs.example-negative-cache.com/", true),
+    ).resolves.toBe(false);
+    expect(lookupMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/__tests__/playwright-scraper.test.ts
+++ b/src/lib/__tests__/playwright-scraper.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isAllowedPlaywrightNavigationUrl,
+  isAllowedPlaywrightNetworkUrl,
+  isAllowedPlaywrightSameHostRequestUrl,
+  isAllowedPlaywrightSubresourceUrl,
+} from "@/lib/playwright-scraper";
+
+const lookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:dns/promises", () => ({
+  default: { lookup: lookupMock },
+  lookup: lookupMock,
+}));
+
+describe("playwright-scraper navigation policy", () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  it("allows public documentation URLs", () => {
+    expect(isAllowedPlaywrightNavigationUrl("https://docs.python.org/3/library/json.html")).toBe(
+      true,
+    );
+    expect(
+      isAllowedPlaywrightNavigationUrl("https://developer.apple.com/documentation/swiftui"),
+    ).toBe(true);
+  });
+
+  it("blocks localhost and private literal hosts even with documentation paths", () => {
+    expect(isAllowedPlaywrightNavigationUrl("https://localhost/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://127.0.0.1/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://10.0.0.5/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://172.16.0.5/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://192.168.1.5/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://169.254.1.5/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://198.18.0.1/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://192.0.2.1/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://192.88.99.1/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://224.0.0.1/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://240.0.0.1/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://[::1]/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://[fd00::1]/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://[fc00::1]/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://[fe80::1]/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://[fec0::1]/docs")).toBe(false);
+    expect(isAllowedPlaywrightNavigationUrl("https://[::ffff:127.0.0.1]/docs")).toBe(false);
+  });
+
+  it("blocks non-https and non-documentation final URLs", () => {
+    expect(isAllowedPlaywrightNavigationUrl("http://docs.python.org/3/library/json.html")).toBe(
+      false,
+    );
+    expect(isAllowedPlaywrightNavigationUrl("https://example.com/")).toBe(false);
+  });
+
+  it("allows public HTTPS subresources but blocks private/local subresources", () => {
+    expect(isAllowedPlaywrightSubresourceUrl("https://cdn.example.com/app.js")).toBe(true);
+    expect(isAllowedPlaywrightSubresourceUrl("http://cdn.example.com/app.js")).toBe(false);
+    expect(isAllowedPlaywrightSubresourceUrl("https://127.0.0.1/app.js")).toBe(false);
+    expect(isAllowedPlaywrightSubresourceUrl("https://[fd00::1]/app.js")).toBe(false);
+    expect(isAllowedPlaywrightSubresourceUrl("https://[::ffff:127.0.0.1]/app.js")).toBe(false);
+  });
+
+  it("allows only same-host Playwright requests after DNS pinning", () => {
+    expect(
+      isAllowedPlaywrightSameHostRequestUrl(
+        "https://docs.python.org/static/app.js",
+        "docs.python.org",
+        false,
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedPlaywrightSameHostRequestUrl(
+        "https://cdn.python.org/static/app.js",
+        "docs.python.org",
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedPlaywrightSameHostRequestUrl(
+        "https://docs.python.org/3/library/json.html",
+        "docs.python.org",
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks documentation hostnames that resolve to private addresses", async () => {
+    lookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+    await expect(isAllowedPlaywrightNetworkUrl("https://docs.example.com/", true)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("allows public HTTPS subresources that resolve to public addresses", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+
+    await expect(
+      isAllowedPlaywrightNetworkUrl("https://cdn.example.com/app.js", false),
+    ).resolves.toBe(true);
+  });
+});

--- a/src/lib/__tests__/scrape-provider.test.ts
+++ b/src/lib/__tests__/scrape-provider.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  getProviderCacheKey,
+  resolveScrapeProvider,
+  ScrapeProviderConfigError,
+} from "@/lib/scrape-provider";
+
+describe("scrape-provider", () => {
+  it("defaults to Firecrawl", () => {
+    expect(resolveScrapeProvider(undefined)).toBe("firecrawl");
+  });
+
+  it("accepts Playwright case-insensitively", () => {
+    expect(resolveScrapeProvider(" Playwright ")).toBe("playwright");
+  });
+
+  it("rejects unsupported providers", () => {
+    expect(() => resolveScrapeProvider("crawl4ai")).toThrow(ScrapeProviderConfigError);
+  });
+
+  it("keeps Firecrawl cache keys stable and scopes Playwright keys", () => {
+    expect(getProviderCacheKey("firecrawl", "https://docs.example.com")).toBe(
+      "https://docs.example.com",
+    );
+    expect(getProviderCacheKey("playwright", "https://docs.example.com")).toBe(
+      "playwright:https://docs.example.com",
+    );
+  });
+});

--- a/src/lib/cache/redis-cache.ts
+++ b/src/lib/cache/redis-cache.ts
@@ -219,7 +219,7 @@ export class RedisCache {
     }
 
     this.stats.misses++;
-    console.log(`[CACHE MISS] ${url} (will need Firecrawl)`);
+    console.log(`[CACHE MISS] ${url} (will need provider fetch)`);
     return null;
   }
 

--- a/src/lib/playwright-scraper.ts
+++ b/src/lib/playwright-scraper.ts
@@ -47,7 +47,13 @@ export class PlaywrightRequestError extends Error {
   }
 }
 
-const dnsResolutionCache = new Map<string, Promise<string | null>>();
+const DNS_CACHE_TTL_MS = 5 * 60 * 1000;
+const DNS_NEGATIVE_CACHE_TTL_MS = 30 * 1000;
+
+const dnsResolutionCache = new Map<
+  string,
+  { promise: Promise<string | null>; expiresAt: number }
+>();
 
 export async function scrapePlaywrightUrl(
   url: string,
@@ -94,7 +100,9 @@ export async function scrapePlaywrightUrl(
       timeout,
       args: isIP(navigationHost)
         ? []
-        : [`--host-resolver-rules=MAP ${navigationHost} ${pinnedAddress}`],
+        : [
+            `--host-resolver-rules=MAP ${navigationHost} ${formatHostResolverAddress(pinnedAddress)}`,
+          ],
     });
 
     context = await browser.newContext({
@@ -200,8 +208,7 @@ export async function scrapePlaywrightUrl(
     if (error instanceof PlaywrightRequestError) throw error;
 
     const message = stripAnsi(error instanceof Error ? error.message : "Unknown Playwright error");
-    const isBrowserInstallError =
-      message.includes("Executable doesn't exist") || message.includes("browserType.launch");
+    const isBrowserInstallError = message.includes("Executable doesn't exist");
     const isExtractionError = message.includes("page.evaluate");
 
     throw new PlaywrightRequestError(
@@ -311,18 +318,31 @@ async function resolvePublicHostname(hostname: string): Promise<string | null> {
   if (isPrivateOrLocalHostname(host)) return null;
   if (isIP(host)) return host;
 
+  const now = Date.now();
   let cached = dnsResolutionCache.get(host);
-  if (!cached) {
-    cached = lookup(host, { all: true, verbatim: true })
+  if (!cached || cached.expiresAt <= now) {
+    const promise = lookup(host, { all: true, verbatim: true })
       .then((records) => {
         const safeRecord = records.find((record) => !isPrivateOrLocalHostname(record.address));
         return safeRecord?.address || null;
       })
       .catch(() => null);
+    cached = { promise, expiresAt: now + DNS_CACHE_TTL_MS };
     dnsResolutionCache.set(host, cached);
   }
 
-  return cached;
+  const result = await cached.promise;
+  if (result === null) {
+    const current = dnsResolutionCache.get(host);
+    if (current?.promise === cached.promise) {
+      current.expiresAt = Date.now() + DNS_NEGATIVE_CACHE_TTL_MS;
+    }
+  }
+  return result;
+}
+
+function formatHostResolverAddress(address: string): string {
+  return address.includes(":") ? `[${address}]` : address;
 }
 
 function isPrivateOrLocalHostname(hostname: string): boolean {
@@ -473,7 +493,11 @@ function extractMarkdownFromPage(requestedURL) {
       const href = element.getAttribute('href');
       if (!text) return '';
       if (!href || href.startsWith('#') || href.startsWith('javascript:')) return text;
-      return '[' + text + '](' + new URL(href, window.location.href).href + ')';
+      try {
+        return '[' + text + '](' + new URL(href, window.location.href).href + ')';
+      } catch {
+        return text;
+      }
     }
 
     if (tag === 'ul' || tag === 'ol') {

--- a/src/lib/playwright-scraper.ts
+++ b/src/lib/playwright-scraper.ts
@@ -1,0 +1,540 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { PROCESSING_CONFIG } from "@/constants";
+import { isValidDocumentationUrl } from "@/utils/url-utils";
+
+interface PlaywrightScrapeMetadata {
+  sourceURL?: string;
+  url?: string;
+  title?: string;
+  requestedURL?: string;
+  provider: "playwright";
+  status?: number;
+  [key: string]: unknown;
+}
+
+export interface PlaywrightScrapeResponse {
+  success: boolean;
+  error?: string;
+  data?: {
+    markdown?: string;
+    metadata?: PlaywrightScrapeMetadata;
+  };
+}
+
+interface PageExtractionResult {
+  markdown: string;
+  blockedReason?: string;
+  metadata: PlaywrightScrapeMetadata;
+}
+
+export interface PlaywrightScrapeOptions {
+  waitFor?: number;
+  timeout?: number;
+}
+
+export class PlaywrightRequestError extends Error {
+  status: number;
+  retryable: boolean;
+  details?: unknown;
+
+  constructor(message: string, status: number, retryable = false, details?: unknown) {
+    super(message);
+    this.name = "PlaywrightRequestError";
+    this.status = status;
+    this.retryable = retryable;
+    this.details = details;
+  }
+}
+
+const dnsResolutionCache = new Map<string, Promise<string | null>>();
+
+export async function scrapePlaywrightUrl(
+  url: string,
+  options: PlaywrightScrapeOptions = {},
+): Promise<PlaywrightScrapeResponse> {
+  await assertAllowedPlaywrightNavigationUrl(url);
+
+  const timeout =
+    readPositiveInteger(process.env.PLAYWRIGHT_TIMEOUT_MS, options.timeout) ??
+    PROCESSING_CONFIG.FIRECRAWL_TIMEOUT;
+  const waitFor =
+    readPositiveInteger(process.env.PLAYWRIGHT_WAIT_MS, options.waitFor) ??
+    PROCESSING_CONFIG.FIRECRAWL_WAIT_TIME;
+
+  let browser: import("playwright").Browser | null = null;
+  let context: import("playwright").BrowserContext | null = null;
+
+  try {
+    const { chromium } = await import("playwright");
+    const wsEndpoint = process.env.PLAYWRIGHT_WS_ENDPOINT?.trim();
+
+    if (wsEndpoint) {
+      throw new PlaywrightRequestError(
+        "PLAYWRIGHT_WS_ENDPOINT is not supported because remote browser DNS cannot be pinned safely. Unset it to launch local Chromium.",
+        500,
+        false,
+      );
+    }
+
+    const navigationHost = normalizeHostname(new URL(url).hostname);
+    const pinnedAddress = await resolvePublicHostname(navigationHost);
+
+    if (!pinnedAddress) {
+      throw new PlaywrightRequestError(
+        "Playwright navigation was blocked because the URL does not resolve to a public address.",
+        400,
+        false,
+        { url },
+      );
+    }
+
+    browser = await chromium.launch({
+      headless: true,
+      timeout,
+      args: isIP(navigationHost)
+        ? []
+        : [`--host-resolver-rules=MAP ${navigationHost} ${pinnedAddress}`],
+    });
+
+    context = await browser.newContext({
+      userAgent: "Mozilla/5.0 (compatible; Documentation-Scraper/1.0)",
+      javaScriptEnabled: true,
+      serviceWorkers: "block",
+    });
+
+    let blockedNavigationUrl: string | null = null;
+
+    await context.routeWebSocket("**/*", async (webSocket) => {
+      await webSocket.close({
+        code: 1008,
+        reason: "WebSocket egress is disabled for Playwright scraping.",
+      });
+    });
+
+    await context.route("**/*", async (route) => {
+      const resourceType = route.request().resourceType();
+      const requestUrl = route.request().url();
+
+      if (!isAllowedPlaywrightSameHostRequestUrl(requestUrl, navigationHost, false)) {
+        if (resourceType === "document") blockedNavigationUrl = requestUrl;
+        await route.abort("blockedbyclient");
+        return;
+      }
+
+      if (
+        resourceType === "document" &&
+        !isAllowedPlaywrightSameHostRequestUrl(requestUrl, navigationHost, true)
+      ) {
+        blockedNavigationUrl = requestUrl;
+        await route.abort("blockedbyclient");
+        return;
+      }
+
+      if (resourceType === "image" || resourceType === "media" || resourceType === "font") {
+        await route.abort();
+        return;
+      }
+
+      await route.continue();
+    });
+
+    const page = await context.newPage();
+
+    let response: import("playwright").Response | null = null;
+    try {
+      response = await page.goto(url, { waitUntil: "domcontentloaded", timeout });
+    } catch (error) {
+      if (blockedNavigationUrl) {
+        throw new PlaywrightRequestError(
+          "Playwright navigation was blocked because the final URL is not an allowed public documentation URL.",
+          400,
+          false,
+          { url: blockedNavigationUrl },
+        );
+      }
+      throw error;
+    }
+
+    const status = response?.status();
+    const finalUrl = response?.url() || page.url();
+
+    assertAllowedPlaywrightSameHostNavigationUrl(finalUrl, navigationHost);
+
+    if (status && status >= 400) {
+      throw new PlaywrightRequestError(
+        status === 404 ? "Page not found. Please check the URL." : `Page returned HTTP ${status}.`,
+        status,
+        status >= 500 || status === 429,
+      );
+    }
+
+    try {
+      await page.waitForLoadState("networkidle", { timeout: waitFor });
+    } catch {
+      // Some documentation sites keep long-polling or analytics requests open.
+    }
+
+    const extraction = (await page.evaluate(
+      `(() => {\n${PLAYWRIGHT_EXTRACTOR_SOURCE}\nreturn extractMarkdownFromPage(${JSON.stringify(url)});\n})()`,
+    )) as PageExtractionResult;
+
+    if (extraction.blockedReason) {
+      throw new PlaywrightRequestError(extraction.blockedReason, 403, false, extraction.metadata);
+    }
+
+    if (!extraction.markdown.trim()) {
+      throw new PlaywrightRequestError("Playwright returned empty page content.", 500, true);
+    }
+
+    extraction.metadata.status = status;
+
+    return {
+      success: true,
+      data: {
+        markdown: extraction.markdown,
+        metadata: extraction.metadata,
+      },
+    };
+  } catch (error) {
+    if (error instanceof PlaywrightRequestError) throw error;
+
+    const message = stripAnsi(error instanceof Error ? error.message : "Unknown Playwright error");
+    const isBrowserInstallError =
+      message.includes("Executable doesn't exist") || message.includes("browserType.launch");
+    const isExtractionError = message.includes("page.evaluate");
+
+    throw new PlaywrightRequestError(
+      isBrowserInstallError
+        ? "Playwright browser is not installed. Run `pnpm exec playwright install chromium` on the self-hosted server."
+        : `Playwright scrape failed: ${message}`,
+      500,
+      !isBrowserInstallError && !isExtractionError,
+    );
+  } finally {
+    await context?.close().catch(() => undefined);
+    await browser?.close().catch(() => undefined);
+  }
+}
+
+function readPositiveInteger(
+  value: string | undefined,
+  fallback: number | undefined,
+): number | null {
+  const parsed = value ? Number.parseInt(value, 10) : fallback;
+  if (!parsed || !Number.isFinite(parsed) || parsed <= 0) return null;
+  return Math.trunc(parsed);
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
+}
+
+export function isAllowedPlaywrightNavigationUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "https:" &&
+      isValidDocumentationUrl(parsed.toString()) &&
+      !isPrivateOrLocalHostname(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedPlaywrightSubresourceUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && !isPrivateOrLocalHostname(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export async function isAllowedPlaywrightNetworkUrl(
+  url: string,
+  requireDocumentationUrl: boolean,
+): Promise<boolean> {
+  if (requireDocumentationUrl) {
+    if (!isAllowedPlaywrightNavigationUrl(url)) return false;
+  } else if (!isAllowedPlaywrightSubresourceUrl(url)) {
+    return false;
+  }
+
+  const parsed = new URL(url);
+  return (await resolvePublicHostname(parsed.hostname)) !== null;
+}
+
+export function isAllowedPlaywrightSameHostRequestUrl(
+  url: string,
+  expectedHostname: string,
+  requireDocumentationUrl: boolean,
+): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = normalizeHostname(parsed.hostname);
+
+    if (host !== normalizeHostname(expectedHostname)) return false;
+    if (requireDocumentationUrl) return isAllowedPlaywrightNavigationUrl(url);
+    return isAllowedPlaywrightSubresourceUrl(url);
+  } catch {
+    return false;
+  }
+}
+
+async function assertAllowedPlaywrightNavigationUrl(url: string): Promise<void> {
+  if (await isAllowedPlaywrightNetworkUrl(url, true)) return;
+
+  throw new PlaywrightRequestError(
+    "Playwright navigation was blocked because the URL is not an allowed public documentation URL.",
+    400,
+    false,
+    { url },
+  );
+}
+
+function assertAllowedPlaywrightSameHostNavigationUrl(url: string, expectedHostname: string): void {
+  if (isAllowedPlaywrightSameHostRequestUrl(url, expectedHostname, true)) return;
+
+  throw new PlaywrightRequestError(
+    "Playwright navigation was blocked because the final URL is not an allowed public documentation URL.",
+    400,
+    false,
+    { url },
+  );
+}
+
+async function resolvePublicHostname(hostname: string): Promise<string | null> {
+  const host = normalizeHostname(hostname);
+
+  if (isPrivateOrLocalHostname(host)) return null;
+  if (isIP(host)) return host;
+
+  let cached = dnsResolutionCache.get(host);
+  if (!cached) {
+    cached = lookup(host, { all: true, verbatim: true })
+      .then((records) => {
+        const safeRecord = records.find((record) => !isPrivateOrLocalHostname(record.address));
+        return safeRecord?.address || null;
+      })
+      .catch(() => null);
+    dnsResolutionCache.set(host, cached);
+  }
+
+  return cached;
+}
+
+function isPrivateOrLocalHostname(hostname: string): boolean {
+  const host = normalizeHostname(hostname);
+
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".local") ||
+    host === "0.0.0.0"
+  ) {
+    return true;
+  }
+
+  if (host === "::" || host === "::1") {
+    return true;
+  }
+
+  if (host.startsWith("::ffff:")) {
+    return true;
+  }
+
+  if (host.includes(":")) {
+    const firstHextet = Number.parseInt(host.split(":")[0] || "0", 16);
+    return (
+      (firstHextet >= 0xfc00 && firstHextet <= 0xfdff) ||
+      (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) ||
+      (firstHextet >= 0xfec0 && firstHextet <= 0xfeff)
+    );
+  }
+
+  const octets = host.split(".").map((part) => Number.parseInt(part, 10));
+  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part))) return false;
+
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) ||
+    (a === 192 && b === 88 && octets[2] === 99) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && octets[2] === 100) ||
+    (a === 203 && b === 0 && octets[2] === 113) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a >= 224
+  );
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, "");
+}
+
+const PLAYWRIGHT_EXTRACTOR_SOURCE = String.raw`
+function extractMarkdownFromPage(requestedURL) {
+  function selectContentRoot() {
+    const selectors = [
+      'article',
+      'main',
+      '[role="main"]',
+      '.theme-doc-markdown',
+      '.documentation',
+      '.docs',
+      '.content',
+    ];
+    for (const selector of selectors) {
+      const element = document.querySelector(selector);
+      if (element && element.textContent && element.textContent.trim()) return element;
+    }
+    return document.body;
+  }
+
+  function normalizeWhitespace(text) {
+    return String(text || '').replace(/\s+/g, ' ');
+  }
+
+  function languageFromCodeElement(code) {
+    const className = (code && code.getAttribute('class')) || '';
+    const match = className.match(/language-([a-z0-9_-]+)/i);
+    return (match && match[1]) || '';
+  }
+
+  function tableToMarkdown(element) {
+    const rows = Array.from(element.querySelectorAll('tr'))
+      .map((row) =>
+        Array.from(row.querySelectorAll('th,td'))
+          .map((cell) => normalizeWhitespace(cell.textContent).replace(/\|/g, '\\|'))
+          .filter(Boolean),
+      )
+      .filter((cells) => cells.length > 0);
+    if (rows.length === 0) return '';
+    const header = rows[0];
+    const separator = header.map(() => '---');
+    const body = rows.slice(1);
+    return '\n\n' + [header, separator, ...body].map((cells) => '| ' + cells.join(' | ') + ' |').join('\n') + '\n\n';
+  }
+
+  function childMarkdown(element, listDepth) {
+    return Array.from(element.childNodes).map((child) => nodeToMarkdown(child, listDepth)).join('');
+  }
+
+  function listItemToMarkdown(element, orderedIndex, listDepth) {
+    if (element.tagName.toLowerCase() !== 'li') return '';
+    const marker = orderedIndex ? String(orderedIndex) + '.' : '-';
+    const indent = '  '.repeat(listDepth);
+    const text = childMarkdown(element, listDepth + 1)
+      .trim()
+      .replace(/\n{2,}/g, '\n')
+      .replace(/\n/g, '\n' + indent + '  ');
+    return text ? indent + marker + ' ' + text + '\n' : '';
+  }
+
+  function nodeToMarkdown(node, listDepth) {
+    listDepth = listDepth || 0;
+    if (node.nodeType === Node.TEXT_NODE) return normalizeWhitespace(node.textContent);
+    if (node.nodeType !== Node.ELEMENT_NODE) return '';
+
+    const element = node;
+    const tag = element.tagName.toLowerCase();
+
+    if (tag === 'br') return '\n';
+    if (tag === 'hr') return '\n\n---\n\n';
+
+    if (/^h[1-6]$/.test(tag)) {
+      const level = Number.parseInt(tag.slice(1), 10);
+      const text = childMarkdown(element, listDepth).trim();
+      return text ? '\n\n' + '#'.repeat(level) + ' ' + text + '\n\n' : '';
+    }
+
+    if (tag === 'pre') {
+      const code = element.querySelector('code');
+      const language = languageFromCodeElement(code);
+      const text = ((code && code.textContent) || element.textContent || '').replace(/\n+$/, '');
+      return text ? '\n\n\`\`\`' + language + '\n' + text + '\n\`\`\`\n\n' : '';
+    }
+
+    if (tag === 'code') {
+      const text = normalizeWhitespace(element.textContent);
+      const tick = String.fromCharCode(96);
+      return text ? tick + text.replace(new RegExp(tick, 'g'), '\\' + tick) + tick : '';
+    }
+
+    if (tag === 'a') {
+      const text = childMarkdown(element, listDepth).trim() || normalizeWhitespace(element.textContent);
+      const href = element.getAttribute('href');
+      if (!text) return '';
+      if (!href || href.startsWith('#') || href.startsWith('javascript:')) return text;
+      return '[' + text + '](' + new URL(href, window.location.href).href + ')';
+    }
+
+    if (tag === 'ul' || tag === 'ol') {
+      return '\n' + Array.from(element.children)
+        .map((child, index) => listItemToMarkdown(child, tag === 'ol' ? index + 1 : null, listDepth))
+        .join('') + '\n';
+    }
+
+    if (tag === 'table') return tableToMarkdown(element);
+
+    if (['p', 'div', 'section', 'article', 'main', 'blockquote'].includes(tag)) {
+      const text = childMarkdown(element, listDepth).trim();
+      if (!text) return '';
+      return tag === 'blockquote' ? '\n\n> ' + text + '\n\n' : '\n\n' + text + '\n\n';
+    }
+
+    return childMarkdown(element, listDepth);
+  }
+
+  function normalizeMarkdown(markdown) {
+    return markdown
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .replace(/^\s+|\s+$/g, '');
+  }
+
+  const bodyText = (document.body && document.body.innerText) || '';
+  const lowerBodyText = bodyText.toLowerCase();
+  const verificationIndicators = [
+    'verify you are human',
+    'checking your browser',
+    'enable javascript and cookies',
+    'attention required',
+    'access denied',
+  ];
+  const blockedIndicator = verificationIndicators.find((indicator) => lowerBodyText.includes(indicator));
+  const metadata = {
+    sourceURL: window.location.href,
+    url: window.location.href,
+    title: document.title || undefined,
+    requestedURL,
+    provider: 'playwright',
+  };
+
+  if (blockedIndicator) {
+    return {
+      markdown: '',
+      blockedReason: 'Page appears to be behind a verification wall. Playwright cannot extract it honestly.',
+      metadata,
+    };
+  }
+
+  const root = selectContentRoot();
+  const clone = root.cloneNode(true);
+  clone
+    .querySelectorAll('script,style,noscript,svg,canvas,iframe,nav,header,footer,aside,form,button,input,select,textarea,[aria-hidden="true"]')
+    .forEach((node) => node.remove());
+
+  return {
+    markdown: normalizeMarkdown(nodeToMarkdown(clone)),
+    metadata,
+  };
+}
+`;

--- a/src/lib/playwright-scraper.ts
+++ b/src/lib/playwright-scraper.ts
@@ -526,6 +526,7 @@ function extractMarkdownFromPage(requestedURL) {
 
   const bodyText = (document.body && document.body.innerText) || '';
   const lowerBodyText = bodyText.toLowerCase();
+  const titleText = (document.title || '').toLowerCase();
   const verificationIndicators = [
     'verify you are human',
     'checking your browser',
@@ -533,7 +534,27 @@ function extractMarkdownFromPage(requestedURL) {
     'attention required',
     'access denied',
   ];
-  const blockedIndicator = verificationIndicators.find((indicator) => lowerBodyText.includes(indicator));
+  function looksLikeVerificationWall() {
+    const shortBody = lowerBodyText.length < 2000;
+    const hasChallengeContainer = Boolean(
+      document.querySelector('[id*="challenge"],[class*="challenge"],[id*="captcha"],[class*="captcha"],.cf-browser-verification'),
+    );
+    const strongBodySignals = [
+      'verify you are human',
+      'checking your browser',
+      'enable javascript and cookies',
+    ];
+    const weakBodySignals = ['attention required', 'access denied'];
+    const hasStrongTitle = strongBodySignals.some((indicator) => titleText.includes(indicator));
+    const hasWeakTitle = weakBodySignals.some((indicator) => titleText.includes(indicator));
+    return (
+      hasStrongTitle ||
+      hasChallengeContainer ||
+      strongBodySignals.some((indicator) => lowerBodyText.includes(indicator)) ||
+      (shortBody && hasWeakTitle) ||
+      (shortBody && weakBodySignals.some((indicator) => lowerBodyText.includes(indicator)))
+    );
+  }
   const metadata = {
     sourceURL: window.location.href,
     url: window.location.href,
@@ -542,7 +563,7 @@ function extractMarkdownFromPage(requestedURL) {
     provider: 'playwright',
   };
 
-  if (blockedIndicator) {
+  if (looksLikeVerificationWall()) {
     return {
       markdown: '',
       blockedReason: 'Page appears to be behind a verification wall. Playwright cannot extract it honestly.',

--- a/src/lib/scrape-provider.ts
+++ b/src/lib/scrape-provider.ts
@@ -1,0 +1,31 @@
+export type ScrapeProvider = "firecrawl" | "playwright";
+
+export class ScrapeProviderConfigError extends Error {
+  status = 500;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ScrapeProviderConfigError";
+  }
+}
+
+export function resolveScrapeProvider(value = process.env.SCRAPE_PROVIDER): ScrapeProvider {
+  const provider = (value || "firecrawl").trim().toLowerCase();
+
+  if (provider === "firecrawl" || provider === "playwright") {
+    return provider;
+  }
+
+  throw new ScrapeProviderConfigError(
+    `Unsupported SCRAPE_PROVIDER "${value}". Use "firecrawl" or "playwright".`,
+  );
+}
+
+export function getProviderCacheKey(provider: ScrapeProvider, url: string): string {
+  if (provider === "firecrawl") return url;
+  return `${provider}:${url}`;
+}
+
+export function getProviderName(provider: ScrapeProvider): string {
+  return provider === "firecrawl" ? "Firecrawl" : "Playwright";
+}


### PR DESCRIPTION
## Summary

Fixes #19.

Adds an opt-in self-hosted scrape provider using local Playwright Chromium:

- `SCRAPE_PROVIDER=firecrawl` remains the default and preserves the existing Firecrawl scrape/crawl path.
- `SCRAPE_PROVIDER=playwright` enables local Chromium rendering for single-page scraping and the existing client-side recursive scraping flow.
- Firecrawl deep crawl mode stays Firecrawl-only and now returns a clear 501 when selected with the Playwright provider.
- Playwright cache entries use provider-scoped keys, while existing Firecrawl cache keys are unchanged.
- Docs and env examples cover provider selection, browser install, deployment constraints, and the Firecrawl/Playwright tradeoff.

The Playwright provider is deliberately local-only. It rejects remote browser endpoints because remote DNS cannot be pinned safely. Runtime hardening resolves the initial hostname to public A/AAAA records before launch, pins Chromium host resolution, allows only same-host HTTPS document/subresource requests, validates the final document URL, blocks private/local/special-use literals, blocks service workers, and closes WebSockets.

## Candidate and Tradeoffs

Recommended path: land this if the project wants a low-operational-burden self-hosted alternative for rendered single-page documentation extraction. It avoids a second crawler service and keeps Firecrawl as the mature default.

Delete or hold this if the desired alternative must match Firecrawl crawl-mode semantics, must support remote browser pools, or must allow arbitrary cross-host page dependencies. Those are intentionally out of scope here because they increase SSRF and deployment burden.

Markdown extraction is good for docs pages but lighter than Firecrawl's hosted extraction pipeline. This PR keeps the provider contract bounded instead of introducing a larger crawler abstraction prematurely.

## Proof

Local verification:

- `pnpm exec playwright install chromium`
- `pnpm run verify`
- Result: lint, type-check, tests, coverage, and production build passed.
- Test result: 22 files, 296 tests passed.

Live built-service proof with `SCRAPE_PROVIDER=playwright`, production build, and `pnpm start`:

- Static page: `https://docs.python.org/3/library/json.html` returned 200 via provider `playwright`; 30,120 markdown chars; 524 lines; 12 headings; 15 code blocks; title `json — JSON encoder and decoder — Python 3.14.6 documentation`.
- JS-rendered page: `https://developer.apple.com/documentation/swiftui/view` returned 200 via provider `playwright`; 25,121 markdown chars; 347 lines; 15 headings; 3 code blocks; title `View | Apple Developer Documentation`.
- Messy docs page: `https://tailwindcss.com/docs/installation/using-vite` returned 200 via provider `playwright`; 3,009 markdown chars; 102 lines; 9 headings; 6 code blocks; title `Installing Tailwind CSS with Vite - Tailwind CSS`.
- Failure page: `https://docs.python.org/3/does-not-exist-llm-codes.html` returned 404 with `Page not found. Please check the URL.`
- Misconfiguration: `PLAYWRIGHT_WS_ENDPOINT=ws://127.0.0.1:9` returned 500 with `PLAYWRIGHT_WS_ENDPOINT is not supported because remote browser DNS cannot be pinned safely. Unset it to launch local Chromium.`
- Blocked private/special-use URLs: `https://127.0.0.1/docs`, `https://198.18.0.1/docs`, `https://[fd00::1]/docs`, `https://[fec0::1]/docs`, and `https://[::ffff:127.0.0.1]/docs` all returned 400 before browser navigation.

Firecrawl live comparison was blocked because no `FIRECRAWL_API_KEY` was exported or present in the local env files, and the exact 1Password item `Firecrawl` was not available in the Molty vault. I did not broaden secret enumeration. The existing Firecrawl path remains the default and is covered by focused route tests.

Autoreview:

- Final autoreview result: clean, no accepted/actionable findings.
- `overall: patch is correct (0.82)`

Public Model Identifier Gate:

- PASS across the final diff and relevant tree files.
- No public model identifiers or real secrets found; only normal placeholder/test env names were present in earlier broad scans.

Official behavior references used:

- Playwright browser install docs: https://playwright.dev/docs/browsers
- Playwright page/API docs including routing and WebSocket routing: https://playwright.dev/docs/api/class-page
- Firecrawl scrape endpoint docs: https://docs.firecrawl.dev/api-reference/endpoint/scrape
- Firecrawl crawl endpoint docs: https://docs.firecrawl.dev/api-reference/endpoint/crawl-post
