### PR TITLE
docs: fix frozen Docker install

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,7 +90,7 @@ pm2 start pnpm --name "llm-codes" -- start
 FROM node:24-alpine
 WORKDIR /app
 RUN corepack enable
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --prod --frozen-lockfile
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
## Summary

- copy `pnpm-workspace.yaml` into the documented Docker dependency layer
- keep frozen installs aligned with the root pnpm override configuration added in PR 21

## Root cause

PR 21 added the PostCSS security override in `pnpm-workspace.yaml`, but the Docker example copied only `package.json` and `pnpm-lock.yaml` before `pnpm install --prod --frozen-lockfile`. pnpm therefore saw lockfile overrides without matching workspace configuration and failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

## Proof

- isolated install with only `package.json` and `pnpm-lock.yaml`: expected failure with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`
- isolated install with the patched three-file copy set: exit 0 under pnpm 10.33.2
- `pnpm run format:check`
- structured autoreview: clean, no accepted/actionable findings

Follow-up to https://github.com/amantus-ai/llm-codes/pull/21#discussion_r3504949155.
